### PR TITLE
Stop PHP warning

### DIFF
--- a/CustomSections.php
+++ b/CustomSections.php
@@ -271,7 +271,7 @@ class CustomSections {
 
 
 
-  public static function PageRunScript($cmd) {
+  static function PageRunScript($cmd) {
     global $page, $addonPathCode, $addonRelativeCode, $addonPathData, $addonRelativeData; 
     //msg('CustomSections::PageRunScript - $cmd = ' .$cmd );
     if( isset($_REQUEST['cmd']) && $_REQUEST['cmd'] == 'custom_sections_cmd' && !empty($_REQUEST['type']) ){


### PR DESCRIPTION
To stop this warning:

> PHP Deprecated:  call_user_func_array() expects parameter 1 to be a valid callback, non-static method CustomSections::PageRunScript() should not be called statically in ...

Maybe there is another solution.