### PR TITLE
Update always_process_values for existing section

### DIFF
--- a/CustomSections_Admin.php
+++ b/CustomSections_Admin.php
@@ -149,6 +149,7 @@ class CustomSections_Admin {
 					$section_file = $addonPathCode . '/_types/' . $val['type']  . '/section.php';
 					include $section_file;
 					$file_sections[$key]['values'] +=$section['values'];
+					$file_sections[$key]['always_process_values'] =$section['always_process_values'];
 					$i++;
 				}
 				if( $i > 0 ){


### PR DESCRIPTION
This allows to change `always_process_values` for existing section when press Recreate Custom Sections.

It is fix for https://github.com/juek/CustomSections/issues/60