### PR TITLE
Trigger bunchControlLoaded event on bunch elements

### DIFF
--- a/universal_editor/editor.js
+++ b/universal_editor/editor.js
@@ -371,6 +371,7 @@ function gp_init_inline_edit(area_id, section_object){
         var control = gp_editor.getControl(value['control_type'], value);
         $gp.div('gp_admin_box').find(".sub_controls_cont").append(control);
       }
+	    $('#editor-ctl-'+value['item']).trigger('CustomSection:bunchControlLoaded');
     });
 
     // callback: Bunch control loaded


### PR DESCRIPTION
Now we trigger the `CustomSection:bunchControlLoaded` event for `document` only. When I want my controls to prepare itself before being shone, they do not receive this event.

I have added triggering `CustomSection:bunchControlLoaded` event for all subcontrols too. 
But, there may be a better way to find subcontrols than the one I use.