### PR TITLE
New place to trigger ...:formElementsLoaded

### DIFF
--- a/universal_editor/editor.js
+++ b/universal_editor/editor.js
@@ -81,8 +81,7 @@ function gp_init_inline_edit(area_id, section_object){
   gp_editor.getFormElements = function(){
     var form_elements = gp_editor.ui.controls
       //.find("input:not(.editor-ctl-no-submit, [type='checkbox'], [type='radio'], [data-applyto]), select:not([data-applyto]), textarea");
-      .find("input:not(.editor-ctl-no-submit, [type='checkbox'], [type='radio']), select, textarea")
-      .trigger("CustomSection:formElementsLoaded");
+      .find("input:not(.editor-ctl-no-submit, [type='checkbox'], [type='radio']), select, textarea");
     return form_elements;
   }; // gp_editor.getFormElements --end
 
@@ -540,6 +539,8 @@ function gp_init_inline_edit(area_id, section_object){
       gp_editor.ui.controls.append(control);
 
     }); // each section_object.values --end
+
+		gp_editor.getFormElements().trigger("CustomSection:formElementsLoaded");
   }; // gp_editor.buildEditorUI --end
 
 

--- a/universal_editor/editor.js
+++ b/universal_editor/editor.js
@@ -78,10 +78,11 @@ function gp_init_inline_edit(area_id, section_object){
 
 
 
-  gp_editor.getFormElements = function(){
+  gp_editor.getFormElements = function(event="CustomSection:formElementsLoaded"){
     var form_elements = gp_editor.ui.controls
       //.find("input:not(.editor-ctl-no-submit, [type='checkbox'], [type='radio'], [data-applyto]), select:not([data-applyto]), textarea");
-      .find("input:not(.editor-ctl-no-submit, [type='checkbox'], [type='radio']), select, textarea");
+      .find("input:not(.editor-ctl-no-submit, [type='checkbox'], [type='radio']), select, textarea")
+      .trigger(event);
     return form_elements;
   }; // gp_editor.getFormElements --end
 
@@ -540,7 +541,7 @@ function gp_init_inline_edit(area_id, section_object){
 
     }); // each section_object.values --end
 
-		gp_editor.getFormElements().trigger("CustomSection:formElementsLoaded");
+    gp_editor.getFormElements("CustomSection:EditorLoaded");
   }; // gp_editor.buildEditorUI --end
 
 


### PR DESCRIPTION
Now the `CustomSection:formElementsLoaded` event is triggered every time `gp_editor.getFormElements` is called. It means when section is saved, updated and Dirty-checked. This is too often and definitely not onLoaded.
I have found a new place to trigger the event only when control elements are created.