### PR TITLE
Add var as marker to detect GetSection() call

### DIFF
--- a/CustomSections.php
+++ b/CustomSections.php
@@ -181,7 +181,8 @@ class CustomSections {
       }
     }
   
-    include $section_file;
+		$GettingSection = true;
+		include $section_file;
 
     // union $current_section with loaded $section -> this only overwrites undefined keys in $current_section
     $current_section += $section;


### PR DESCRIPTION
For section with `$section['always_process_values'] = true;` it is useful to distinguish which function includes section.php at the moment.
With this PR, if `$GettingSection` is set, it tells us that we are in GetSection() call (not in SectionTypes() or LoadSectionCssJs() ) and $sectionCurrentValues is really set with current section values.

Yes, I know your position about my attempts to use CS in a situation where it is much easier to make a normal plugin. But CS is so good as a rapid development tools. And I generally succeed at doing whatever I want in my section.
But sometimes I think that, if `$section['content']` was not an array but a function, it would be much easier to work with a config file, a Session and so on:)