### PR TITLE
Avoid errors when hovering a CS sections in editor

### DIFF
--- a/CustomSections.php
+++ b/CustomSections.php
@@ -205,7 +205,9 @@ class CustomSections {
       $replace[] =  $val;
      }
    }
+   if ( isset($section['content']) ) {
     $current_section['content'] = str_replace($search, $replace, $section['content']);
+   }    
     /* DEBUG level 3 */ if( self::$debug_level > 2 ){ global $addonPathCode; \gp\tool\Files::SaveData($addonPathCode.'/!debug/current_section.php', 'current_section', $current_section); }
     return $current_section;
   }


### PR DESCRIPTION
Now we have such an error when just hovering  a custom section in the section editor.

> PHP Notice:  Undefined index: content in D:\\Internet\\www\\root\\TS-4\\addons\\CustomSections-master\\CustomSections.php on line 208

This PR fix it